### PR TITLE
Hotfix/cannot build

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "graphql": "^0.9.2",
     "graphql-server-express": "^0.6.0",
     "graphql-subscriptions": "^0.3.1",
-    "graphql-tag": "^2.0.0",
+    "graphql-tag": "1.3.2",
     "http-proxy-middleware": "^0.17.4",
     "immutability-helper": "^2.1.2",
     "isomorphic-fetch": "^2.2.1",
@@ -121,7 +121,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "subscriptions-transport-ws": "^0.5.5-alpha.0",
-    "webpack": "^2.2.1",
+    "webpack": "^2.3.3",
     "webpack-dev-middleware": "^1.10.1",
     "webpack-hot-middleware": "^2.17.1"
   },

--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -37,16 +37,16 @@ export default {
         test: /\.css$/,
         exclude: /node_modules/,
         loader: ExtractTextPlugin.extract({
-          fallbackLoader: 'style-loader',
-          loader: 'css-loader',
+          fallback: 'style-loader',
+          use: 'css-loader',
         }),
       },
       {
         test: /\.styl$/,
         exclude: /node_modules/,
         loader: ExtractTextPlugin.extract({
-          fallbackLoader: 'style-loader',
-          loader: [
+          fallback: 'style-loader',
+          use: [
             {
               loader: 'css-loader',
               options: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,7 +2494,7 @@ graphql-subscriptions@^0.3.0, graphql-subscriptions@^0.3.1:
   dependencies:
     es6-promise "^3.2.1"
 
-graphql-tag@^1.2.4, graphql-tag@^1.3.1:
+graphql-tag@1.3.2, graphql-tag@^1.2.4, graphql-tag@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-1.3.2.tgz#7abb3a8fd9f3415d07163314ed237061c785b759"
 
@@ -4380,7 +4380,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@2.1.5, readable-stream@^2.0.1, readable-stream@^2.0.5:
+readable-stream@2.1.5, readable-stream@^2.0.1:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
   dependencies:
@@ -4392,7 +4392,7 @@ readable-stream@2.1.5, readable-stream@^2.0.1, readable-stream@^2.0.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6:
+readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.6.tgz#8b43aed76e71483938d12a8d46c6cf1a00b1f816"
   dependencies:
@@ -5300,7 +5300,7 @@ webpack-sources@^0.2.3:
     source-list-map "^1.1.1"
     source-map "~0.5.3"
 
-webpack@^2.2.1:
+webpack@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.3.3.tgz#eecc083c18fb7bf958ea4f40b57a6640c5a0cc78"
   dependencies:


### PR DESCRIPTION
- Since graphql-tag version 2.0.0 has removed the /printer from its module so we need to downgrade graphql-tag to 1.3.2 in order to make it consistent with subscriptions-transport-ws that use graphql-tag version 1.2.4

- Upgrade webpack and fix warnings